### PR TITLE
fixed zero error when requesting products

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -62,7 +62,10 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
+        try:
+            avg = total_rating / len(ratings)
+        except:
+            avg = 0
         return avg
 
     class Meta:

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -64,9 +64,10 @@ class Product(SafeDeleteModel):
 
         try:
             avg = total_rating / len(ratings)
-        except:
+            return avg
+        except ZeroDivisionError:
             avg = 0
-        return avg
+            return avg
 
     class Meta:
         verbose_name = ("product")


### PR DESCRIPTION
When requesting multiple or single products from `/products`, a division by zero error occurs resulting in a 500 status code server error

## Changes

- Added a try/catch block starting at line 65 which makes the average_rating property 0 if the ratings filter returns no results  

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products` Gets all products

**Response**

HTTP/1.1 200 OK

```json
{
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Onguday",
        "image_path": null,
        "average_rating": 0
    }
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Seed database
- [ ] Test that average_rating is average of all ratings for that product


## Related Issues

- Fixes #11 