### PR TITLE
Product added to closed order

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type = Payment.objects.get(pk=request.data["payment_type"])
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -206,7 +206,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type__isnull=True)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
Prevents items from being added to a closed order. When a POST is sent to `/profile/cart` a new order is created if existing order is closed. 

## Changes

- /views/profile.py line 209 added an additional filter to the object.get that must be null or it passes to the exception block


## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/profile/cart` Add item to cart

```json
{
    "product_id": 88
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 14,
    "product": {
        "id": 88,
        "name": "Element",
        "price": 1727.41,
        "number_sold": 3,
        "description": "2003 Honda",
        "quantity": 3,
        "created_date": "2019-05-28",
        "location": "Dukoh",
        "image_path": null,
        "average_rating": 0
    }
}
```

## Testing

Description of how to test code...

- [ ] Add item to closed cart, then `GET` cart and confirm that cart id is not closed cart id. 


## Related Issues

- Fixes #3