### PR TITLE
profile returns user matching token

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -2,6 +2,7 @@
 import datetime
 from django.http import HttpResponseServerError
 from django.contrib.auth.models import User
+from django.http.response import Http404
 from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
@@ -61,9 +62,11 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user=request.user)
+            current_user = Customer.objects.get(user=request.auth.user)
             serializer = ProfileSerializer(current_user, many=False, context={'request': request})
             return Response(serializer.data)
+        except AttributeError:
+            raise Http404
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -61,7 +61,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user__id=4)
+            current_user = Customer.objects.get(user=request.user)
             serializer = ProfileSerializer(current_user, many=False, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:


### PR DESCRIPTION
When `GET` request is sent to `/profile` it now returns the user object for the current user.

## Changes

- Line 64 of `/views/profile.py` changed Customer object filter from fixed integer to match the request token instead

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

`GET` /profile

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 4,
    "url": "http://localhost:8000/customers/4",
    "user": {
        "first_name": "Steve",
        "last_name": "Brownlee",
        "email": "steve@stevebrownlee.com"
    },
    "phone_number": "555-1212",
    "address": "100 Infinity Way",
    "payment_types": [
        {
            "url": "http://localhost:8000/paymenttypes/4",
            "deleted": null,
            "merchant_name": "Amex",
            "account_number": "000000000000",
            "expiration_date": "2020-12-12",
            "create_date": "2023-12-12",
            "customer": "http://localhost:8000/customers/4"
        }
    ]
}
```

## Testing

Description of how to test code...

- [ ] User retrieved with `/profile` should having matching token to the current user in authtoken_token table

## Related Issues

- Fixes #4