### PR TITLE
Incorrect number sold

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -34,7 +34,7 @@ class Product(SafeDeleteModel):
             int -- Number items on completed orders
         """
         sold = OrderProduct.objects.filter(
-            product=self, order__payment_type__isnull=False)
+            product=self, product_id=self.id)
         return sold.count()
 
     @property

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -266,7 +266,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold == int(number_sold):
                     return True
                 return False
 

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -266,7 +266,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold == int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -61,7 +61,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user__id=4)
+            current_user = Customer.objects.get(user=request.user)
             serializer = ProfileSerializer(current_user, many=False, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:


### PR DESCRIPTION
Fixes `/products` endpoint incorrectly filtering based on the `number_sold` query parameter

## Changes

- `/models/products.py Line 37 changed to correctly filter by `product_id`
- `/views/product.py` Line 269 evaluation changed to correctly choose number sold that is >= ("at least") 

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products?number_sold=2` Gets products filtered by parameter query

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    },
    {
        "id": 88,
        "name": "Element",
        "price": 1727.41,
        "number_sold": 5,
        "description": "2003 Honda",
        "quantity": 3,
        "created_date": "2019-05-28",
        "location": "Dukoh",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing

Description of how to test code...

- [ ] Create products and increase number sold to equal or greater than query number
- [ ] Ensure that GET request only returns products with number_sold field equal or greater than parameter query


## Related Issues

- Fixes #5