### PR TITLE
Incorrect expiry date

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
Users can now POST a new payment type and expiration date will be correctly saved

## Changes

- /views/paymenttype.py Lines 37 & 38 - request keys for expiration_date and create_date were reversed

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/paymenttypes` Creates a payment type

```json
{
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

**Response**

HTTP/1.1 200 OK

```json
{
        "id": 6,
        "url": "http://localhost:8000/paymenttypes/6",
        "merchant_name": "Amex",
        "account_number": "000000000000",
        "expiration_date": "2023-12-12",
        "create_date": "2020-12-12"
 }
```

## Testing

Description of how to test code...

- [ ] Create a new payment type by POSTing to /paymenttypes with an object with above keys
- [ ] Perform a GET at the same endpoint and verify that expiration_date key value is correct


## Related Issues

- Fixes #7