### PR TITLE
Filter payment type

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,7 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
-
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        payment_types = payment_types.filter(customer__id=request.auth.user.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
Correctly filters payment types by the current user

## Changes

- /view/paymenttypes.py Lines 84-86 removed
- /view/paymenttypes.py Line 87 change to filter on the request user rather than a query parameter

## Requests / Responses

**Request**

GET `/paymenttypes` Gets a list of user's created payment types

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 3,
        "url": "http://localhost:8000/paymenttypes/3",
        "merchant_name": "Visa",
        "account_number": "fj0398fjw0g89434",
        "expiration_date": "2020-03-01",
        "create_date": "2019-03-11"
    }
]
```

## Testing

Description of how to test code...

- [ ] Create a new payment type via POST to /paymenttypes endpoint
- [ ] GET at /paymenttypes endpoint should only contain payments created by current user


## Related Issues

- Fixes #8