### PR TITLE
products  minimum price filter added

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -248,6 +248,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        min_price = self.request.query_params.get('min_price', None)
 
         if order is not None:
             order_filter = order
@@ -271,6 +272,13 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if min_price is not None:
+            def minprice_filter(product):
+                if product.price >= int(min_price):
+                    return True
+                return False
+            products = filter(minprice_filter, products)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
Requests to the products endpoint can be filtered by min_price

## Changes

- /views/product.py Line 251 Added min_price variable created from query parameter
- /views/product.py Line 257 Check existence of variable, define filter function, pass products array through filter
- Item 3

## Requests / Responses

**Request**

GET `/products?min_price=n` Gets products greater than or equal to n
**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 20,
        "name": "Mazda6",
        "price": 1900.67,
        "number_sold": 0,
        "description": "2005 Mazda",
        "quantity": 2,
        "created_date": "2018-12-13",
        "location": "Tuburan",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing

Description of how to test code...

- [ ] Pass min_price query parameter on `/products` endpoint and ensure prices of all products returned a equal or greater than that number


## Related Issues

- Fixes #9