### PR TITLE
can filter products by location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -253,6 +253,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
         min_price = self.request.query_params.get('min_price', None)
+        location = self.request.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -283,6 +284,9 @@ class Products(ViewSet):
                     return True
                 return False
             products = filter(minprice_filter, products)
+
+        if location is not None:
+            products = products.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
Added filter to allow filtering products by their location

## Changes

- /views/products Line 256 added location variable for location request data
- /views/products Line 288 added filter to filter products array by query string

## Requests / Responses

**Request**

GET `/products?location=s` Lists products filtered by query string s

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 44,
        "name": "Astro",
        "price": 1486.31,
        "number_sold": 0,
        "description": "2000 Chevrolet",
        "quantity": 4,
        "created_date": "2019-03-25",
        "location": "Denver",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing

Description of how to test code...

- [ ] Perform GET at /products endpoint with a query string of `location` and confirm that results all contain said location


## Related Issues

- Fixes #12