### PR TITLE
Likeordislike

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -10,7 +10,7 @@ from bangazonapi.views import *
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'products', Products, 'product')
 router.register(r'productcategories', ProductCategories, 'productcategory')
-router.register(r'lineitems', LineItems, base_name='orderproduct')
+router.register(r'lineitems', LineItems, 'orderproduct')
 router.register(r'customers', Customers, 'customer')
 router.register(r'users', Users, 'user')
 router.register(r'orders', Orders, 'order')

--- a/bangazonapi/models/__init__.py
+++ b/bangazonapi/models/__init__.py
@@ -8,3 +8,4 @@ from .recommendation import Recommendation
 from .rating import Rating
 from .favorite import Favorite
 from .productrating import ProductRating
+from .productlike import ProductLike

--- a/bangazonapi/models/productlike.py
+++ b/bangazonapi/models/productlike.py
@@ -1,0 +1,9 @@
+from django.db import models
+from .customer import Customer
+from .product import Product
+
+
+class ProductLike(models.Model):
+
+    customer = models.ForeignKey(Customer, related_name='product_likes', on_delete=models.DO_NOTHING,)
+    product = models.ForeignKey(Product, on_delete=models.DO_NOTHING,)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -2,6 +2,7 @@
 import base64
 from django.core.files.base import ContentFile
 from django.http import HttpResponseServerError
+from rest_framework.decorators import action
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
@@ -10,6 +11,7 @@ from bangazonapi.models import Product, Customer, ProductCategory
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.parsers import MultiPartParser, FormParser
 from django.core.exceptions import ValidationError
+
 
 
 class ProductSerializer(serializers.ModelSerializer):
@@ -291,3 +293,10 @@ class Products(ViewSet):
         serializer = ProductSerializer(
             products, many=True, context={'request': request})
         return Response(serializer.data)
+
+    @action(methods=['post', 'delete'], detail=True)
+    def like(self, request, pk=None):
+        customer = Customer.objects.get(user=request.auth.user)
+        product = Product.objects.get(pk=pk)
+        if request.method == 'POST':
+            return Response({"product": product.id})

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -314,6 +314,18 @@ class Products(ViewSet):
                 return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
             except ValidationError as ex:
                 return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
+        
+        if request.method == "DELETE":
+            customer = Customer.objects.get(user=request.auth.user)
+            try:
+                like = ProductLike.objects.get(customer=customer, product=pk)
+                like.delete()
+                return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+            except ProductLike.DoesNotExist as ex:
+                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            except Exception as ex:
+                return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 class ProductLikeSerializer(serializers.ModelSerializer):
     class Meta:

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -334,8 +334,7 @@ class ProductLikeSerializer(serializers.ModelSerializer):
             UniqueTogetherValidator(
                 queryset=ProductLike.objects.all(),
                 fields=['customer', 'product'],
-                message="Customer can like a product more than once"
+                message="Customer can't like a product more than once"
             )
         ]
         fields = ('id', 'customer', 'product')
-        depth = 0


### PR DESCRIPTION
Adds endpoint to allow customer to like or dislike a product

## Changes

- /models/productlike.py New model for product likes
- /views/product.py Lines 5, 10, 14 Added imports to support new action
- /views/product.py Lines 298-328 Add POST and DELETE action methods for /products/n/like endpoint
- /views/product.py Lines 330-341 ProductLike Serializer class

## Requests / Responses

**Request**

POST `/products/n/like` Creates a like by current user for product n

**Response**

HTTP/1.1 204 NO CONTENT

```json
{
    "id": 3,
    "customer": 7,
    "product": 1
}
```

## Testing

Description of how to test code...

- [ ] POST to `/products/n/like` endpoint with a valid product id
- [ ] Check for correct status code and json object returned
- [ ] POST again to same endpoint to ensure no duplicates are entered. Should recieve a 400 BAD REQUEST and ""Customer can like a product more than once" error on duplicate
- [ ] DELETE to same endpoint with same id and check for 204 NO CONTENT status


## Related Issues

- Fixes #14 