### PR TITLE
unit test for complete order

### DIFF
--- a/tests/order.py
+++ b/tests/order.py
@@ -29,6 +29,18 @@ class OrderTests(APITestCase):
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+        #Create a payment type
+        url = "/paymenttypes"
+        data = {
+            "merchant_name": "Amex",
+            "account_number": "000000000000",
+            "expiration_date": "2023-12-12",
+            "create_date": "2020-12-12"
+        }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
 
     def test_add_product_to_order(self):
         """
@@ -80,5 +92,26 @@ class OrderTests(APITestCase):
         self.assertEqual(len(json_response["lineitems"]), 0)
 
     # TODO: Complete order by adding payment type
+
+    def test_complete_order(self):
+
+        #Create an order
+        self.test_add_product_to_order()
+
+        #Update payment type on order
+        url = "/orders/1"
+        data = { "payment_type": 1 }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.put(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        #Get Cart and verify payment_type is not Null
+        url = "/orders/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+        self.assertIsNotNone(json_response["payment_type"])
+
 
     # TODO: New line item is not added to closed order


### PR DESCRIPTION
Unit test for checking if order closes properly when payment type is added

## Changes

- /tests/order.py Line 32-43 Setup for creating a payment type
- /tests/order.py Line 96-114 Unit test creates an order, updates payment_type, gets order and tests for not null

## Testing

Description of how to test code...

- [ ] Run `python manage.py test` and ensure that all tests are run with an OK response in terminal


## Related Issues

- Fixes #15 