### PR TITLE
test for delete method paymenttypes

### DIFF
--- a/tests/payments.py
+++ b/tests/payments.py
@@ -41,3 +41,10 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
+    def test_delete_payment_type(self):
+        self.test_create_payment_type()
+        url = "/paymenttypes/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, None, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Unit Test to check delete method on paymenttypes endpoint

## Changes

- /tests/payments.py Lines 43-50 Unit test for the `paymenttypes` endpoint that creates a payment type, then deletes it and confirms the status code is 204

## Testing

Description of how to test code...

- [ ] Run tests with `python manage.py test` and confirm all pass with OK

## Related Issues

- Fixes #17 