### PR TITLE
unit test for deleting product

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -159,6 +159,8 @@ class Products(ViewSet):
             product = Product.objects.get(pk=pk)
             serializer = ProductSerializer(product, context={'request': request})
             return Response(serializer.data)
+        except Product.DoesNotExist:
+            return Response({"msg": "Product not found"}, status=status.HTTP_404_NOT_FOUND)
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/tests/product.py
+++ b/tests/product.py
@@ -95,7 +95,6 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 3)
 
-    # TODO: Delete product
     def test_delete_product(self):
 
         #create the product

--- a/tests/product.py
+++ b/tests/product.py
@@ -96,5 +96,23 @@ class ProductTests(APITestCase):
         self.assertEqual(len(json_response), 3)
 
     # TODO: Delete product
+    def test_delete_product(self):
+
+        #create the product
+        self.test_create_product()
+
+        # delete the product
+        url = "/products/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, None, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        #check product can no longer be retrieved
+        url = "/products/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        json_response = json.loads(response.content)
+        self.assertEqual(json_response["msg"], "Product not found")
 
     # TODO: Product can be rated. Assert average rating exists.


### PR DESCRIPTION
Unit test to check that product can be properly deleted

## Changes

- /views/products.py Lines 162-163 Added exception to properly handle product not found on retrieve
- /tests/product.py Lines 99-116 Unit test that creates a product, deletes a product, then tries to retrieve product to ensure it is unavailable

## Testing

Description of how to test code...

- [ ] Run test with `python manage.py test` and ensure that all tests pass with OK


## Related Issues

- Fixes #18 