### PR TITLE
incomplete orders report

### DIFF
--- a/bangazonreports/templates/orders/completed_orders.html
+++ b/bangazonreports/templates/orders/completed_orders.html
@@ -1,0 +1,45 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+  <style>
+table {
+  font-family: arial, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+td, th {
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}
+
+tr:nth-child(even) {
+  background-color: #dddddd;
+}
+</style>
+    <meta charset="utf-8">
+    <title>Bangazon Reports - {{ report_title }}</title>
+  </head>
+  <body>
+    <h1>{{ report_title }}</h1>
+  <table>
+  <tr>
+    <th>Order Id</th>
+    <th>Full Name</th>
+    <th>Order Total</th>
+    <th>Payment Type</th>
+  </tr>
+  {% for orders in orders_list %}
+    <tr>
+    <td>{{ orders.orderid }}</td>
+    <td>{{ orders.fullname }}</td>
+    {% load formatting_filters %}
+    <td>{{ orders.total | currency }}</td>
+    <td>{{ orders.payment_type }}</td>
+    </tr>
+  {% endfor %}
+    <table>
+  </body>
+</html>

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import products_over_1000, products_under_1000
+from .views import products_over_1000, products_under_1000, incomplete_orders
 
 urlpatterns = [
     path('reports/expensiveproducts', products_over_1000),
     path('reports/inexpensiveproducts', products_under_1000),
+    path('reports/incompleteorders', incomplete_orders),
 ]

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -1,3 +1,4 @@
 from .connection import Connection
 from .products.expensive_products import products_over_1000
 from .products.inexpensive_products import products_under_1000
+from .orders.incomplete_orders import incomplete_orders

--- a/bangazonreports/views/orders/incomplete_orders.py
+++ b/bangazonreports/views/orders/incomplete_orders.py
@@ -1,0 +1,48 @@
+import sqlite3
+from django.shortcuts import render
+from bangazonapi.models import Product
+from bangazonreports.views import Connection
+
+
+def incomplete_orders(request):
+    if request.method == 'GET':
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+            db_cursor.execute("""
+              SELECT
+	              o.id orderid,
+	              u.first_name || ' ' || u.last_name AS fullname,
+	              SUM (p.price) AS total
+	            FROM bangazonapi_order o
+	            JOIN bangazonapi_orderproduct op ON op.order_id = o.id
+	            JOIN bangazonapi_product p ON p.id = op.product_id
+	            JOIN bangazonapi_customer cust ON o.customer_id = cust.id
+              JOIN auth_user u ON cust.user_id = u.id
+	            WHERE o.payment_type_id IS NULL
+	            GROUP BY o.id
+            """)
+
+            dataset = db_cursor.fetchall()
+
+            orders = {}
+
+            for row in dataset:
+              rowid = row["orderid"]
+              orders[rowid] = {}
+              orders[rowid]["orderid"] = rowid
+              orders[rowid]["fullname"] = row["fullname"]
+              orders[rowid]["total"] = row["total"]
+              orders[rowid]["payment_type"] = 'In Progress'
+                
+        # Get only the values from the dictionary and create a list from them
+        list_of_incomplete_orders = orders.values()
+
+        # Specify the Django template and provide data context
+        template = 'orders/completed_orders.html'
+        context = {
+            'report_title': 'Incomplete Orders',
+            'orders_list': list_of_incomplete_orders
+        }
+
+        return render(request, template, context)


### PR DESCRIPTION
Report for orders that are completed/closed 

## Changes

- bangazonreports/templates/orders/incomplete_orders.html Template for incomplete orders
- bangazonreports/urls.py Lines 2,7 Import path  
- bangazonreports/views/__init__.py Line 4 Import the view
- bangazonreports/views/orders/incomplete_orders.py View supplying data for the template

## Testing

Description of how to test code...

- [ ] Run server with `python manage.py runserver`
- [ ] Visit /reports/completedorders endpoint and verify only closed orders are listed


## Related Issues

- Fixes #23